### PR TITLE
Fixed Panel Height and Updated Podspec

### DIFF
--- a/BSModalPickerView.m
+++ b/BSModalPickerView.m
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
 //
 
-#define BSMODALPICKER_PANEL_HEIGHT 200
+#define BSMODALPICKER_PANEL_HEIGHT 260
 #define BSMODALPICKER_TOOLBAR_HEIGHT 44
 #define BSMODALPICKER_BACKDROP_OPACITY 0.8
 

--- a/BSModalPickerView.podspec
+++ b/BSModalPickerView.podspec
@@ -1,14 +1,14 @@
 Pod::Spec.new do |s|
-  s.name         = "BSModalPickerView"
-  s.version      = "0.1"
-  s.summary      = "A custom UIPickerView with a simple list of options, along with a toolbar for Done/Cancel and a faded backdrop view."
-  s.homepage     = "https://github.com/subdigital/BSModalPickerView"
+  s.name         = 'BSModalPickerView'
+  s.version      = '0.3'
+  s.summary      = 'A custom UIPickerView with a simple list of options, along with a toolbar for Done/Cancel and a faded backdrop view.'
+  s.homepage     = 'https://github.com/subdigital/BSModalPickerView'
 
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
-  s.author       = { "Ben Scheirman" => "ben@scheirman.com" }
+  s.author       = { 'Ben Scheirman' => 'ben@scheirman.com' }
   s.source       = { 
     :git => "https://github.com/subdigital/BSModalPickerView.git", 
-    :tag => "0.1"
+    :tag => "v#{s.version}"
   }
 
   s.platform     = :ios, '4.0'


### PR DESCRIPTION
I've changed the picker's panel height to match all of Apple's demonstrated uses of any sort of modal picker. For example, in the Calendar app, the panel height now matches that of the date picker when you edit an event's start/end time. Additionally, it matches both panel height and toolbar height for Safari's implementation of a modal picker, which can be demonstrated [here](http://www.w3schools.com/tags/tryit.asp?filename=tryhtml_select).

I've also updated the podspec to match CocoaPods's [model podspec](http://docs.cocoapods.org/specification.html).
