### PR TITLE
Correct issue with pickerFrame returning 0 for width

### DIFF
--- a/BSModalPickerView/BSModalPickerBase.m
+++ b/BSModalPickerView/BSModalPickerBase.m
@@ -62,7 +62,7 @@
     if (!_picker) {
         CGRect pickerFrame = CGRectMake(0,
                                         BSMODALPICKER_TOOLBAR_HEIGHT,
-                                        self.bounds.size.width,
+                                        [UIApplication sharedApplication].keyWindow.rootViewController.view.bounds.size.width,
                                         BSMODALPICKER_PANEL_HEIGHT - BSMODALPICKER_TOOLBAR_HEIGHT);
         
         _picker = [self pickerWithFrame:pickerFrame];


### PR DESCRIPTION
First off, love this library. 

I noticed that when I updated via pods that in BSModalPickerBase.m -> picker -> CGRect pickerFrame that self.bounds.size.width was returning 0 in my current iPad application so the picker view was defaulting to 320 wide.

I made a minor change to [UIApplication sharedApplication].keyWindow.rootViewController.view.bounds.size.width

I did try calling the bounds of the superview but that also returned 0.
