### PR TITLE
Implemented a modal picker view for choosing a CGFloat value

### DIFF
--- a/BSModalPickerView/BSModalFloatPickerView.h
+++ b/BSModalPickerView/BSModalFloatPickerView.h
@@ -1,0 +1,22 @@
+//
+//  BSModalFloatPickerView.h
+//
+//  Created by Daryll Herberger on 10/28/13.
+//
+
+#import "BSModalPickerBase.h"
+
+typedef enum {
+    ModalFloatPickerNone = 0,
+    ModalFloatPickerOneSigFig = 1,      ///< Picker should support one significant figure of precision
+	ModalFloatPickerTwoSigFig = 2,		///< Picker should support two significant figures of precision
+    ModalFloatPickerThreeSigFig = 3		///< Picker should support three significant figures of precision
+} ModalFloatPickerPrecision;            ///< @enum Modal Float Picker Precision Enumeration
+
+@interface BSModalFloatPickerView : BSModalPickerBase<UIPickerViewDelegate, UIPickerViewDataSource>
+
+@property (nonatomic) CGFloat maxValue;
+@property (nonatomic) CGFloat selectedValue;
+@property (nonatomic) ModalFloatPickerPrecision precision;
+
+@end

--- a/BSModalPickerView/BSModalFloatPickerView.m
+++ b/BSModalPickerView/BSModalFloatPickerView.m
@@ -1,0 +1,165 @@
+//
+//  BSModalFloatPickerView.m
+//
+//  Created by Daryll Herberger on 10/28/13.
+//
+
+#import "BSModalFloatPickerView.h"
+
+@interface BSModalFloatPickerView () {
+    CGFloat _selectedValue;
+}
+
+@property (nonatomic, weak) UIPickerView *shownPicker;
+
+@end
+
+@implementation BSModalFloatPickerView
+
+#pragma mark - Custom Getters
+
+- (UIView *)pickerWithFrame:(CGRect)pickerFrame {
+    UIPickerView *pickerView = [[UIPickerView alloc] initWithFrame:pickerFrame];
+    pickerView.dataSource = self;
+    pickerView.delegate = self;
+    pickerView.showsSelectionIndicator = YES;
+	pickerView.backgroundColor = [UIColor whiteColor];
+    
+    NSInteger selectedIntegerPart = _selectedValue;
+    [pickerView selectRow:selectedIntegerPart inComponent:0 animated:NO];
+    
+    for (int i = 0; i < self.precision; i++) {
+        NSInteger decimalPlace = i + 1;
+        double integer_part;
+        NSInteger selectedFractionalPart = modf(_selectedValue, &integer_part) * (10 * decimalPlace);
+        [pickerView selectRow:selectedFractionalPart inComponent:decimalPlace animated:NO];
+    }
+    
+    self.shownPicker = pickerView;
+    
+    return pickerView;
+}
+
+#pragma mark - Custom Setters
+
+- (void)setSelectedValue:(CGFloat)selectedValue {
+    _selectedValue = selectedValue;
+    
+    if (_maxValue < _selectedValue) {
+        _selectedValue = _maxValue;
+    }
+    
+    if (self.shownPicker != nil) {
+        [self.shownPicker reloadAllComponents];
+    }
+}
+
+- (void)setMaxValue:(CGFloat)maxValue {
+    _maxValue = maxValue;
+    
+    if (maxValue < _selectedValue) {
+        _selectedValue = maxValue;
+    }
+    
+    if (self.shownPicker != nil) {
+        [self.shownPicker reloadAllComponents];
+    }
+}
+
+#pragma mark - Picker View Data Source
+
+- (NSInteger)numberOfComponentsInPickerView:(UIPickerView *)pickerView {
+    return self.precision + 1;
+}
+
+- (NSInteger)pickerView:(UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component {
+    NSInteger result = 0;
+    
+    switch (component) {
+        case 0: {
+            result = self.maxValue + 1;
+            break;
+        }
+        default: {
+            NSInteger selectedIntegerPart = _selectedValue;
+            NSInteger maxValueIntegerPart = self.maxValue;
+            if (selectedIntegerPart == maxValueIntegerPart) {
+                CGFloat maxRepresentable = 0.0;
+                CGFloat maxSigFigPart = self.maxValue;
+                CGFloat relativeSigFigPart = _selectedValue;
+                
+                for (int sigFig = 0; sigFig < component; sigFig++) {
+                    double maxIntegerPart, relativeIntegerPart;
+                    maxSigFigPart = (CGFloat)modf(maxSigFigPart, &maxIntegerPart) * 10;
+                    relativeSigFigPart = (CGFloat)modf(relativeSigFigPart, &relativeIntegerPart) * 10;
+                    
+                    if (sigFig == 0) {
+                        maxRepresentable = relativeIntegerPart;
+                    } else {
+                        maxRepresentable += relativeIntegerPart / pow(10, sigFig);
+                    }
+                }
+                
+                NSInteger sigFigDigitMax = maxSigFigPart;
+                maxRepresentable += sigFigDigitMax / pow(10, component);
+                maxRepresentable += 9 / pow(10, component + 1);
+                
+                if (maxRepresentable < self.maxValue) {
+                    result = 10;
+                } else {
+                    result = sigFigDigitMax + 1;
+                }
+            } else {
+                result = 10;
+            }
+
+            break;
+        }
+    }
+    
+    return result;
+}
+
+#pragma mark - Picker View Delegate
+
+- (CGFloat)pickerView:(UIPickerView *)pickerView widthForComponent:(NSInteger)component {
+    CGFloat result = 0.0f;
+    
+    switch (component) {
+        case 0: {
+            NSInteger maxValueIntegerPart = self.maxValue;
+            NSInteger numberOfDigits = [[NSString stringWithFormat:@"%d", maxValueIntegerPart] length];
+            CGFloat widthForRange = 25.0f * numberOfDigits;
+            result = widthForRange;
+            break;
+        }
+        default: {
+            result = 25.0f;
+            break;
+        }
+    }
+    
+    return result;
+}
+
+- (NSString *)pickerView:(UIPickerView *)pickerView titleForRow:(NSInteger)row forComponent:(NSInteger)component {
+    NSString *result = nil;
+    
+    result = [NSString stringWithFormat:@"%d", row];
+    
+    return result;
+}
+
+- (void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component {
+    _selectedValue = [pickerView selectedRowInComponent:0];
+    
+    for (int i = 0; i < self.precision; i++) {
+        NSInteger decimalPlace = i + 1;
+        
+        _selectedValue += (CGFloat)[pickerView selectedRowInComponent:decimalPlace] / (CGFloat)(pow(10, decimalPlace));
+    }
+    
+    [pickerView reloadAllComponents];
+}
+
+@end


### PR DESCRIPTION
Needed to implement a picker for a floating point value, rather than perform additional validation steps off of a standard keyboard entry. As I was already utilizing your library to handle pickers in my app, I decided to implement this as a variant off of the BSModalPickerBase and to contribute my work back to your project in case you found it to be a useful offshoot.

Features:
- Accepts a maximum CGFloat value
- Works for presenting a picker for up to 3 significant figures
- Automatically adjusts the various digit selection wheels to ensure the resulting selected value does not exceed the maximum value

Cheers!
