### PR TITLE
Adding range picker support - the ability to build pickers for value ranges

### DIFF
--- a/BSModalPickerView/BSModalDatePickerView.m
+++ b/BSModalPickerView/BSModalDatePickerView.m
@@ -29,6 +29,8 @@
 - (UIView *)pickerWithFrame:(CGRect)pickerFrame {
     UIDatePicker *datePicker = [[UIDatePicker alloc] initWithFrame:pickerFrame];
 
+    datePicker.backgroundColor = [UIColor whiteColor];
+    
     if (self.selectedDate) {
         datePicker.date = self.selectedDate;
     }

--- a/BSModalPickerView/BSModalFloatRangePickerView.h
+++ b/BSModalPickerView/BSModalFloatRangePickerView.h
@@ -1,0 +1,19 @@
+//
+//  BSModalFloatRangePickerView.h
+//  GolfNow
+//
+//  Created by Cameron Hall on 3/26/15.
+//  Copyright (c) 2015 Vertigo. All rights reserved.
+//
+//
+
+#import "BSModalRangePickerBase.h"
+
+@interface BSModalFloatRangePickerView : BSModalRangePickerBase
+
+- (instancetype)initWithFloatInterval:(CGFloat)floatInterval andMinRange:(CGFloat)minRangeValue andMaxRange:(CGFloat)maxRangeValue;
+
+- (void)setSelectedMinValue:(CGFloat)minValue;
+- (void)setSelectedMaxValue:(CGFloat)maxValue;
+
+@end

--- a/BSModalPickerView/BSModalFloatRangePickerView.m
+++ b/BSModalPickerView/BSModalFloatRangePickerView.m
@@ -1,0 +1,92 @@
+//
+//  BSModalFloatRangePickerView.m
+//  GolfNow
+//
+//  Created by Cameron Hall on 3/26/15.
+//  Copyright (c) 2015 Vertigo. All rights reserved.
+//
+
+#import "BSModalFloatRangePickerView.h"
+
+@interface BSModalFloatRangePickerView()
+
+@property (nonatomic) CGFloat floatInterval;
+
+@property (nonatomic) CGFloat minRangeValue;
+@property (nonatomic) CGFloat maxRangeValue;
+
+@end
+
+@implementation BSModalFloatRangePickerView
+
+- (instancetype)initWithFloatInterval:(CGFloat)floatInterval andMinRange:(CGFloat)minRangeValue andMaxRange:(CGFloat)maxRangeValue {
+    if (self = [super init]) {
+        self.minRangeValue = minRangeValue;
+        self.maxRangeValue = maxRangeValue;
+        self.floatInterval = floatInterval;
+        
+        if (self.minRangeValue > self.maxRangeValue) {
+            self.maxRangeValue = self.minRangeValue;
+        }
+        
+        [self calculateRangeValues];
+    }
+    
+    return self;
+}
+
+#pragma mark - BSModalRangePickerBase
+
+- (void)calculateRangeValues {
+    CGFloat rangeDiff = self.maxRangeValue - self.minRangeValue;
+    NSInteger numberOfValues = rangeDiff / self.floatInterval + 1;
+    NSMutableArray *rangeValues = [NSMutableArray array];
+    
+    for (NSInteger i = 0; i < numberOfValues; ++i) {
+        NSNumber *value = [NSNumber numberWithFloat:i * self.floatInterval];
+        [rangeValues addObject:value];
+    }
+    
+    self.rangeValues = rangeValues;
+}
+
+- (NSString *)formatValue:(id)value forComponent:(NSInteger)component {
+    NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
+    numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
+
+    NSString *formattedValue = [numberFormatter stringFromNumber:value];
+    return formattedValue;
+}
+
+#pragma mark - Public
+
+- (void)setSelectedMinValue:(CGFloat)minValue {
+    for (NSNumber *value in self.rangeValues) {
+        if ([BSModalFloatRangePickerView floatValue:[value floatValue] isEqualToFloat:minValue]) {
+            [self setSelectedMinRowIndex:[self.rangeValues indexOfObject:value]];
+            break;
+        }
+    }
+}
+
+- (void)setSelectedMaxValue:(CGFloat)maxValue {
+    for (NSNumber *value in self.rangeValues) {
+        if ([BSModalFloatRangePickerView floatValue:[value floatValue] isEqualToFloat:maxValue]) {
+            [self setSelectedMaxRowIndex:[self.rangeValues indexOfObject:value]];
+            break;
+        }
+    }
+}
+
+#pragma mark - Private
+
++ (BOOL)floatValue:(CGFloat)firstValue isEqualToFloat:(CGFloat)secondValue {
+    double diff = fabs(firstValue - secondValue);
+    firstValue = fabs(firstValue);
+    secondValue = fabs(secondValue);
+    double largest = (secondValue > firstValue) ? secondValue : firstValue;
+    return (diff <= largest * FLT_EPSILON);
+}
+
+@end
+

--- a/BSModalPickerView/BSModalPickerView.m
+++ b/BSModalPickerView/BSModalPickerView.m
@@ -31,6 +31,7 @@
 
 - (UIView *)pickerWithFrame:(CGRect)pickerFrame {
     UIPickerView *pickerView = [[UIPickerView alloc] initWithFrame:pickerFrame];
+    pickerView.backgroundColor = [UIColor whiteColor];
     pickerView.dataSource = self;
     pickerView.delegate = self;
     pickerView.showsSelectionIndicator = YES;

--- a/BSModalPickerView/BSModalRangePickerBase.h
+++ b/BSModalPickerView/BSModalRangePickerBase.h
@@ -1,0 +1,21 @@
+//
+//  BSModalRangePickerBase.h
+//  GolfNow
+//
+//  Created by Cameron Hall on 3/26/15.
+//  Copyright (c) 2015 Vertigo. All rights reserved.
+//
+
+#import "BSModalPickerBase.h"
+
+@interface BSModalRangePickerBase : BSModalPickerBase<UIPickerViewDelegate, UIPickerViewDataSource>
+
+@property (nonatomic, strong) NSArray *rangeValues;
+
+@property (nonatomic) NSUInteger selectedMinRowIndex;
+@property (nonatomic) NSUInteger selectedMaxRowIndex;
+
+- (id)selectedMaxValue;
+- (id)selectedMinValue;
+
+@end

--- a/BSModalPickerView/BSModalRangePickerBase.m
+++ b/BSModalPickerView/BSModalRangePickerBase.m
@@ -1,0 +1,129 @@
+//
+//  BSModalRangePickerBase.m
+//  GolfNow
+//
+//  Created by Cameron Hall on 3/26/15.
+//  Copyright (c) 2015 Vertigo. All rights reserved.
+//
+
+#import "BSModalRangePickerBase.h"
+
+@implementation BSModalRangePickerBase
+
+- (UIView *)pickerWithFrame:(CGRect)pickerFrame {
+    UIPickerView *pickerView = [[UIPickerView alloc] initWithFrame:pickerFrame];
+    pickerView.showsSelectionIndicator = YES;
+    pickerView.backgroundColor = [UIColor whiteColor];
+    pickerView.delegate = self;
+    pickerView.dataSource = self;
+    self.picker = pickerView;
+    
+    return pickerView;
+}
+
+#pragma mark - Private
+
+- (id)valueAtIndex:(NSInteger)index forComponent:(NSInteger)component {
+    
+    if (component == 1) {
+        index += self.selectedMinRowIndex;
+    }
+        
+    return [self.rangeValues objectAtIndex:index];
+}
+
+- (NSInteger)indexOfValue:(id)value forComponent:(NSInteger)component {
+    NSInteger result = [self.rangeValues indexOfObject:value];
+    
+    if (component == 1) {
+        result -= self.selectedMinRowIndex;
+    }
+    
+    return result;
+}
+
+- (NSString *)formattedValueAtIndex:(NSInteger)index forComponent:(NSInteger)component {
+    id value = [self valueAtIndex:index forComponent:component];
+    return [self formatValue:value forComponent:component];
+}
+
+#pragma mark - Public
+
+- (id)selectedMaxValue {
+    NSInteger index = self.selectedMaxRowIndex + self.selectedMinRowIndex;
+    
+    if (self.rangeValues && [self.rangeValues count] > index) {
+        return [self.rangeValues objectAtIndex:index];
+    }
+    
+    return nil;
+}
+
+- (id)selectedMinValue {
+    if (self.rangeValues && [self.rangeValues count] > self.selectedMinRowIndex) {
+        return [self.rangeValues objectAtIndex:self.selectedMinRowIndex];
+    }
+    
+    return nil;
+}
+
+#pragma mark - Subclass-implemented methods
+
+- (void)calculateRangeValues {
+    [NSException raise:NSGenericException
+                format:@"calculateRangeValues: must be implemented by a subclass"];
+}
+
+- (NSString *)formatValue:(id)value forComponent:(NSInteger)component {
+    [NSException raise:NSGenericException
+                format:@"formatValue:forComponent: must be implemented by a subclass"];
+    return nil;
+}
+
+#pragma mark - Picker View Data Source
+
+- (NSInteger)numberOfComponentsInPickerView:(UIPickerView *)pickerView {
+    return 2;
+}
+
+- (NSInteger)pickerView:(UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component {
+    NSInteger rowCount = [self.rangeValues count];
+    
+    if (component == 1) {
+        rowCount -= self.selectedMinRowIndex;
+    }
+    
+    return rowCount;
+}
+
+#pragma mark - Picker View Delegate
+
+- (NSString *)pickerView:(UIPickerView *)pickerView titleForRow:(NSInteger)row forComponent:(NSInteger)component {
+    NSString *result = [self formattedValueAtIndex:row forComponent:component];
+    
+    return result;
+}
+
+- (void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component {
+    if (component == 0) {
+        id maxValue = [self valueAtIndex:self.selectedMaxRowIndex forComponent:1];
+        
+        self.selectedMinRowIndex = row;
+        [pickerView reloadAllComponents];
+        
+        NSInteger newMaxValueIndex = [self indexOfValue:maxValue forComponent:1];
+       
+        if (newMaxValueIndex < 0) {
+            newMaxValueIndex = 0;
+        }
+        
+        self.selectedMaxRowIndex = newMaxValueIndex;
+        
+        [pickerView selectRow:newMaxValueIndex inComponent:1 animated:NO];
+        
+    } else {
+        self.selectedMaxRowIndex = row;
+    }
+}
+
+@end

--- a/BSModalPickerView/BSModalTimeRangePickerView.h
+++ b/BSModalPickerView/BSModalTimeRangePickerView.h
@@ -1,0 +1,18 @@
+//
+//  BSModalTimeRangePickerView.h
+//  GolfNow
+//
+//  Created by Daryll Herberger on 3/24/15.
+//  Copyright (c) 2015 Vertigo. All rights reserved.
+//
+
+#import "BSModalRangePickerBase.h"
+
+@interface BSModalTimeRangePickerView : BSModalRangePickerBase
+
+- (instancetype)initWithTimeInterval:(double)timeInterval andMinRange:(NSDate*)minRangeValue andMaxRange:(NSDate *)maxRangeValue;
+
+- (void)setSelectedMinValue:(NSDate *)minValue;
+- (void)setSelectedMaxValue:(NSDate *)maxValue;
+
+@end

--- a/BSModalPickerView/BSModalTimeRangePickerView.m
+++ b/BSModalPickerView/BSModalTimeRangePickerView.m
@@ -1,0 +1,91 @@
+//
+//  BSModalTimeRangePickerView.m
+//  GolfNow
+//
+//  Created by Daryll Herberger on 3/24/15.
+//  Copyright (c) 2015 Vertigo. All rights reserved.
+//
+
+#import "BSModalTimeRangePickerView.h"
+
+@interface BSModalTimeRangePickerView ()
+
+@property (nonatomic) double numberOfMinutesInRange;
+@property (nonatomic) NSUInteger rangeIntervalInMinutes;
+
+@property (nonatomic, strong) NSDate *maxRangeValue;
+@property (nonatomic, strong) NSDate *minRangeValue;
+
+@end
+
+@implementation BSModalTimeRangePickerView
+
+- (instancetype)initWithTimeInterval:(double)timeInterval andMinRange:(NSDate *)minRangeValue andMaxRange:(NSDate *)maxRangeValue {
+    if (self = [super init]) {
+        self.rangeIntervalInMinutes = timeInterval;
+        self.minRangeValue = minRangeValue;
+        self.maxRangeValue = maxRangeValue;
+        
+        if ([minRangeValue earlierDate:maxRangeValue] == maxRangeValue) {
+            self.minRangeValue = maxRangeValue;
+        }
+        
+        [self calculateRangeValues];
+    }
+    
+    return self;
+}
+
+#pragma mark - BSModalRangePickerBase
+
+- (void)calculateRangeValues {
+    self.numberOfMinutesInRange = [self.maxRangeValue timeIntervalSinceDate:self.minRangeValue] / 60;
+    
+    NSMutableArray *values = [NSMutableArray array];
+    NSInteger numberOfRowsInComponent = self.numberOfMinutesInRange / self.rangeIntervalInMinutes;
+
+    for (NSInteger i = 0; i < numberOfRowsInComponent; i++) {
+        NSInteger numberOfMinutesFromRangeMin = self.rangeIntervalInMinutes * i;
+        NSDate *componentRowValue = [self.minRangeValue dateByAddingTimeInterval:numberOfMinutesFromRangeMin * 60];
+        [values addObject:componentRowValue];
+    }
+
+    self.rangeValues = values;
+}
+
+- (NSString *)formatValue:(id)value forComponent:(NSInteger)component {
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setTimeStyle:NSDateFormatterShortStyle];
+    [dateFormatter setDateStyle:NSDateFormatterNoStyle];
+    [dateFormatter setLocale:[NSLocale currentLocale]];
+
+    NSString *result = [dateFormatter stringFromDate:value];
+
+    return result;
+}
+
+#pragma mark - Public
+
+- (void)setSelectedMinValue:(NSDate *)minValue {
+    if (minValue) {
+        for (NSDate *value in self.rangeValues) {
+            if ([value timeIntervalSinceDate:minValue] == 0) {
+                [self setSelectedMinRowIndex:[self.rangeValues indexOfObject:value]];
+                break;
+            }
+        }
+    }
+}
+
+- (void)setSelectedMaxValue:(NSDate *)maxValue {
+    if (maxValue) {
+        for (NSDate *value in self.rangeValues) {
+            if ([value timeIntervalSinceDate:maxValue] == 0) {
+                [self setSelectedMaxRowIndex:[self.rangeValues indexOfObject:value]];
+                break;
+            }
+        }
+    }
+}
+
+@end

--- a/ModalPickerDemo/ModalPickerDemo.xcodeproj/project.pbxproj
+++ b/ModalPickerDemo/ModalPickerDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		312762041ACCA0B3001084EF /* BSModalFloatRangePickerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 312761FF1ACCA0B3001084EF /* BSModalFloatRangePickerView.m */; };
+		312762051ACCA0B3001084EF /* BSModalRangePickerBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 312762011ACCA0B3001084EF /* BSModalRangePickerBase.m */; };
+		312762061ACCA0B3001084EF /* BSModalTimeRangePickerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 312762031ACCA0B3001084EF /* BSModalTimeRangePickerView.m */; };
 		B500DAFB17563C4900E08D3B /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B500DAFA17563C4900E08D3B /* UIKit.framework */; };
 		B500DAFD17563C4900E08D3B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B500DAFC17563C4900E08D3B /* Foundation.framework */; };
 		B500DAFF17563C4900E08D3B /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B500DAFE17563C4900E08D3B /* CoreGraphics.framework */; };
@@ -24,6 +27,12 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		312761FE1ACCA0B3001084EF /* BSModalFloatRangePickerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSModalFloatRangePickerView.h; sourceTree = "<group>"; };
+		312761FF1ACCA0B3001084EF /* BSModalFloatRangePickerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSModalFloatRangePickerView.m; sourceTree = "<group>"; };
+		312762001ACCA0B3001084EF /* BSModalRangePickerBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSModalRangePickerBase.h; sourceTree = "<group>"; };
+		312762011ACCA0B3001084EF /* BSModalRangePickerBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSModalRangePickerBase.m; sourceTree = "<group>"; };
+		312762021ACCA0B3001084EF /* BSModalTimeRangePickerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSModalTimeRangePickerView.h; sourceTree = "<group>"; };
+		312762031ACCA0B3001084EF /* BSModalTimeRangePickerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSModalTimeRangePickerView.m; sourceTree = "<group>"; };
 		B500DAF717563C4900E08D3B /* ModalPickerDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ModalPickerDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B500DAFA17563C4900E08D3B /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		B500DAFC17563C4900E08D3B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -122,10 +131,16 @@
 			children = (
 				B5A7E07917565C8F005A49C4 /* BSModalDatePickerView.h */,
 				B5A7E07A17565C8F005A49C4 /* BSModalDatePickerView.m */,
+				312761FE1ACCA0B3001084EF /* BSModalFloatRangePickerView.h */,
+				312761FF1ACCA0B3001084EF /* BSModalFloatRangePickerView.m */,
 				B5A7E07B17565C8F005A49C4 /* BSModalPickerBase.h */,
 				B5A7E07C17565C8F005A49C4 /* BSModalPickerBase.m */,
 				B5A7E07D17565C8F005A49C4 /* BSModalPickerView.h */,
 				B5A7E07E17565C8F005A49C4 /* BSModalPickerView.m */,
+				312762001ACCA0B3001084EF /* BSModalRangePickerBase.h */,
+				312762011ACCA0B3001084EF /* BSModalRangePickerBase.m */,
+				312762021ACCA0B3001084EF /* BSModalTimeRangePickerView.h */,
+				312762031ACCA0B3001084EF /* BSModalTimeRangePickerView.m */,
 			);
 			name = BSModalPickerView;
 			path = ../BSModalPickerView;
@@ -197,9 +212,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				312762041ACCA0B3001084EF /* BSModalFloatRangePickerView.m in Sources */,
 				B500DB0717563C4900E08D3B /* main.m in Sources */,
 				B500DB0B17563C4900E08D3B /* AppDelegate.m in Sources */,
+				312762051ACCA0B3001084EF /* BSModalRangePickerBase.m in Sources */,
 				B500DB1417563C4900E08D3B /* ViewController.m in Sources */,
+				312762061ACCA0B3001084EF /* BSModalTimeRangePickerView.m in Sources */,
 				B5A7E07F17565C8F005A49C4 /* BSModalDatePickerView.m in Sources */,
 				B5A7E08017565C8F005A49C4 /* BSModalPickerBase.m in Sources */,
 				B5A7E08117565C8F005A49C4 /* BSModalPickerView.m in Sources */,

--- a/ModalPickerDemo/ModalPickerDemo/ViewController.h
+++ b/ModalPickerDemo/ModalPickerDemo/ViewController.h
@@ -10,9 +10,11 @@
 
 @interface ViewController : UIViewController
 
-@property (weak, nonatomic) IBOutlet UILabel *dateLabel;
+@property (weak, nonatomic) IBOutlet UILabel *resultLabel;
 
 - (IBAction)onSelectColor:(id)sender;
 - (IBAction)onSelectDate:(id)sender;
+- (IBAction)onSelectFloatRange:(id)sender;
+- (IBAction)onSelectTimeRange:(id)sender;
 
 @end

--- a/ModalPickerDemo/ModalPickerDemo/ViewController.m
+++ b/ModalPickerDemo/ModalPickerDemo/ViewController.m
@@ -9,6 +9,8 @@
 #import "ViewController.h"
 #import "BSModalPickerView.h"
 #import "BSModalDatePickerView.h"
+#import "BSModalFloatRangePickerView.h"
+#import "BSModalTimeRangePickerView.h"
 
 @interface ViewController () {
     NSInteger _lastSelectedIndex;
@@ -57,9 +59,66 @@
                         if (madeChoice) {
                             NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
                             [dateFormatter setDateStyle:NSDateFormatterLongStyle];
-                            self.dateLabel.text = [dateFormatter stringFromDate:datePicker.selectedDate];
+                            [self.resultLabel setText:[dateFormatter stringFromDate:datePicker.selectedDate]];
                         }
                     }];
+}
+
+- (IBAction)onSelectFloatRange:(id)sender {
+    BSModalFloatRangePickerView *floatRangePicker = [[BSModalFloatRangePickerView alloc] initWithFloatInterval:0.525 andMinRange:0.0 andMaxRange:10.5];
+    [floatRangePicker presentInView:self.view
+                    withBlock:^(BOOL madeChoice) {
+                        if (madeChoice) {
+                            NSNumber *selectedMin = [floatRangePicker selectedMinValue];
+                            NSNumber *selectedMax = [floatRangePicker selectedMaxValue];
+                            
+                            NSString *rangeString = [NSString stringWithFormat:@"%@ - %@", [selectedMin stringValue], [selectedMax stringValue]];
+
+                            [self.resultLabel setText:rangeString];
+                        }
+                    }];
+}
+
+- (IBAction)onSelectTimeRange:(id)sender {
+    // Get a minimum value starting at the last half hour
+    NSDateComponents *time = [[NSCalendar currentCalendar]
+                              components:NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit |  NSHourCalendarUnit | NSMinuteCalendarUnit
+                              fromDate:[NSDate date]];
+    NSInteger minutes = [time minute];
+    float minuteUnit = floor((float) minutes / 30.0);
+    minutes = minuteUnit * 30.0;
+    [time setMinute: minutes];
+    NSDate *minRangeDate =  [[NSCalendar currentCalendar] dateFromComponents:time];
+
+    // Get a maximum value ending 6 hours away or end of day, end of the hour
+    minutes = 0;
+    NSInteger hours = [time hour];
+    
+    if (hours + 6 < 24) {
+        [time setHour:hours + 6];
+    } else {
+        [time setHour:23];
+    }
+    
+    NSDate *maxRangeDate =  [[NSCalendar currentCalendar] dateFromComponents:time];
+
+    BSModalTimeRangePickerView *timeRangePicker = [[BSModalTimeRangePickerView alloc] initWithTimeInterval:15 andMinRange:minRangeDate andMaxRange:maxRangeDate];
+    [timeRangePicker presentInView:self.view
+                          withBlock:^(BOOL madeChoice) {
+                              if (madeChoice) {
+                                  NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+                                  [dateFormatter setDateStyle:NSDateFormatterNoStyle];
+                                  [dateFormatter setTimeStyle:NSDateFormatterShortStyle];
+                                  [dateFormatter setLocale:[NSLocale currentLocale]];
+                                  
+                                  NSString *selectedMin = [dateFormatter stringFromDate:[timeRangePicker selectedMinValue]];
+                                  NSString *selectedMax = [dateFormatter stringFromDate:[timeRangePicker selectedMaxValue]];
+                                  
+                                  NSString *rangeString = [NSString stringWithFormat:@"%@ - %@", selectedMin, selectedMax];
+                                  
+                                  [self.resultLabel setText:rangeString];
+                              }
+                          }];
 }
 
 @end

--- a/ModalPickerDemo/ModalPickerDemo/en.lproj/ViewController.xib
+++ b/ModalPickerDemo/ModalPickerDemo/en.lproj/ViewController.xib
@@ -2,16 +2,15 @@
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
 	<data>
 		<int key="IBDocument.SystemTarget">1552</int>
-		<string key="IBDocument.SystemVersion">12D78</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.37</string>
-		<string key="IBDocument.HIToolboxVersion">626.00</string>
+		<string key="IBDocument.SystemVersion">14C1514</string>
+		<string key="IBDocument.InterfaceBuilderVersion">6751</string>
+		<string key="IBDocument.AppKitVersion">1344.72</string>
+		<string key="IBDocument.HIToolboxVersion">757.30</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">2083</string>
+			<string key="NS.object.0">6736</string>
 		</object>
 		<array key="IBDocument.IntegratedClassDependencies">
-			<string>IBNSLayoutConstraint</string>
 			<string>IBProxyObject</string>
 			<string>IBUIButton</string>
 			<string>IBUILabel</string>
@@ -40,8 +39,9 @@
 					<object class="IBUIButton" id="1016960852">
 						<reference key="NSNextResponder" ref="774585933"/>
 						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{195, 86}, {105, 44}}</string>
+						<string key="NSFrame">{{194, 86}, {106, 44}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="587036035"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
@@ -49,25 +49,26 @@
 						<int key="IBUIContentHorizontalAlignment">0</int>
 						<int key="IBUIContentVerticalAlignment">0</int>
 						<int key="IBUIButtonType">1</int>
-						<string key="IBUINormalTitle">Select Date</string>
+						<object class="NSColor" key="IBUINormalTitleColor" id="163461017">
+							<int key="NSColorSpace">1</int>
+							<bytes key="NSRGB">MC4xOTYwNzg0MzE0IDAuMzA5ODAzOTIxNiAwLjUyMTU2ODYyNzUAA</bytes>
+						</object>
 						<object class="NSColor" key="IBUIHighlightedTitleColor" id="745262582">
 							<int key="NSColorSpace">3</int>
 							<bytes key="NSWhite">MQA</bytes>
 						</object>
-						<object class="NSColor" key="IBUINormalTitleColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
-						</object>
+						<string key="IBUINormalTitle">Select Date</string>
 						<object class="NSColor" key="IBUINormalTitleShadowColor" id="389541368">
 							<int key="NSColorSpace">3</int>
 							<bytes key="NSWhite">MC41AA</bytes>
 						</object>
 						<object class="IBUIFontDescription" key="IBUIFontDescription" id="804749851">
 							<int key="type">2</int>
+							<int key="weightCategory">30</int>
 							<double key="pointSize">15</double>
 						</object>
-						<object class="NSFont" key="IBUIFont" id="595645065">
-							<string key="NSName">Helvetica-Bold</string>
+						<object class="NSFont" key="IBUIFont" id="769265615">
+							<string key="NSName">HelveticaNeue</string>
 							<double key="NSSize">15</double>
 							<int key="NSfFlags">16</int>
 						</object>
@@ -75,8 +76,9 @@
 					<object class="IBUIButton" id="261442737">
 						<reference key="NSNextResponder" ref="774585933"/>
 						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{20, 86}, {112, 44}}</string>
+						<string key="NSFrame">{{20, 86}, {111, 44}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="1016960852"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
@@ -84,28 +86,27 @@
 						<int key="IBUIContentHorizontalAlignment">0</int>
 						<int key="IBUIContentVerticalAlignment">0</int>
 						<int key="IBUIButtonType">1</int>
-						<string key="IBUINormalTitle">Select Color</string>
+						<reference key="IBUINormalTitleColor" ref="163461017"/>
 						<reference key="IBUIHighlightedTitleColor" ref="745262582"/>
-						<object class="NSColor" key="IBUINormalTitleColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
-						</object>
+						<string key="IBUINormalTitle">Select Color</string>
 						<reference key="IBUINormalTitleShadowColor" ref="389541368"/>
 						<reference key="IBUIFontDescription" ref="804749851"/>
-						<reference key="IBUIFont" ref="595645065"/>
+						<reference key="IBUIFont" ref="769265615"/>
 					</object>
 					<object class="IBUILabel" id="587036035">
 						<reference key="NSNextResponder" ref="774585933"/>
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{20, 170}, {280, 34}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="591450706"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClipsSubviews">YES</bool>
 						<int key="IBUIContentMode">7</int>
 						<bool key="IBUIUserInteractionEnabled">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<string key="IBUIText">(select a date)</string>
+						<string key="IBUIText">(select a date or range)</string>
 						<object class="NSColor" key="IBUITextColor">
 							<int key="NSColorSpace">1</int>
 							<bytes key="NSRGB">MC4yNzM2MDE1MTc0IDAuNDI5NTgxMzUxOSAwLjMzNzc4NDA2NDgAA</bytes>
@@ -115,18 +116,66 @@
 						<int key="IBUITextAlignment">1</int>
 						<object class="IBUIFontDescription" key="IBUIFontDescription">
 							<int key="type">2</int>
+							<int key="weightCategory">30</int>
 							<double key="pointSize">21</double>
 						</object>
 						<object class="NSFont" key="IBUIFont">
-							<string key="NSName">Helvetica-Bold</string>
+							<string key="NSName">HelveticaNeue</string>
 							<double key="NSSize">21</double>
 							<int key="NSfFlags">16</int>
 						</object>
 						<bool key="IBUIAdjustsFontSizeToFit">NO</bool>
+						<bool key="useAutomaticPreferredMaxLayoutWidth">YES</bool>
+					</object>
+					<object class="IBUIButton" id="591450706">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{20, 243}, {148, 44}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="1036339194"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<int key="IBUIContentHorizontalAlignment">0</int>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<int key="IBUIButtonType">1</int>
+						<reference key="IBUINormalTitleColor" ref="163461017"/>
+						<reference key="IBUIHighlightedTitleColor" ref="745262582"/>
+						<string key="IBUINormalTitle">Select float range</string>
+						<reference key="IBUINormalTitleShadowColor" ref="389541368"/>
+						<object class="IBUIFontDescription" key="IBUIFontDescription" id="47763091">
+							<int key="type">2</int>
+							<int key="weightCategory">0</int>
+							<double key="pointSize">15</double>
+						</object>
+						<object class="NSFont" key="IBUIFont" id="121974074">
+							<string key="NSName">HelveticaNeue-Bold</string>
+							<double key="NSSize">15</double>
+							<int key="NSfFlags">16</int>
+						</object>
+					</object>
+					<object class="IBUIButton" id="1036339194">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{21, 333}, {147, 44}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<int key="IBUIContentHorizontalAlignment">0</int>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<int key="IBUIButtonType">1</int>
+						<reference key="IBUINormalTitleColor" ref="163461017"/>
+						<reference key="IBUIHighlightedTitleColor" ref="745262582"/>
+						<string key="IBUINormalTitle">Select time range</string>
+						<reference key="IBUINormalTitleShadowColor" ref="389541368"/>
+						<reference key="IBUIFontDescription" ref="47763091"/>
+						<reference key="IBUIFont" ref="121974074"/>
 					</object>
 				</array>
 				<string key="NSFrame">{{0, 20}, {320, 548}}</string>
 				<reference key="NSSuperview"/>
+				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="261442737"/>
 				<object class="NSColor" key="IBUIBackgroundColor">
 					<int key="NSColorSpace">1</int>
@@ -136,6 +185,8 @@
 				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
 				<object class="IBUIScreenMetrics" key="IBUISimulatedDestinationMetrics">
 					<string key="IBUISimulatedSizeMetricsClass">IBUIScreenMetrics</string>
+					<string key="IBUITargetRuntime">IBCocoaTouchFramework</string>
+					<string key="IBUIDisplayName">iPhone 4-inch</string>
 					<object class="NSMutableDictionary" key="IBUINormalizedOrientationToSizeMap">
 						<bool key="EncodedWithXMLCoder">YES</bool>
 						<array key="dict.sortedKeys">
@@ -147,15 +198,13 @@
 							<string>{568, 320}</string>
 						</array>
 					</object>
-					<string key="IBUITargetRuntime">IBCocoaTouchFramework</string>
-					<string key="IBUIDisplayName">Retina 4 Full Screen</string>
 					<int key="IBUIType">2</int>
 				</object>
 				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 			</object>
 		</array>
 		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords">
+			<array key="connectionRecords">
 				<object class="IBConnectionRecord">
 					<object class="IBCocoaTouchOutletConnection" key="connection">
 						<string key="label">view</string>
@@ -166,11 +215,11 @@
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">dateLabel</string>
+						<string key="label">resultLabel</string>
 						<reference key="source" ref="372490531"/>
 						<reference key="destination" ref="587036035"/>
 					</object>
-					<int key="connectionID">37</int>
+					<int key="connectionID">51</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBCocoaTouchEventConnection" key="connection">
@@ -189,6 +238,24 @@
 						<int key="IBEventType">7</int>
 					</object>
 					<int key="connectionID">35</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchEventConnection" key="connection">
+						<string key="label">onSelectFloatRange:</string>
+						<reference key="source" ref="591450706"/>
+						<reference key="destination" ref="372490531"/>
+						<int key="IBEventType">7</int>
+					</object>
+					<int key="connectionID">52</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchEventConnection" key="connection">
+						<string key="label">onSelectTimeRange:</string>
+						<reference key="source" ref="1036339194"/>
+						<reference key="destination" ref="372490531"/>
+						<int key="IBEventType">7</int>
+					</object>
+					<int key="connectionID">53</int>
 				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
@@ -214,121 +281,11 @@
 						<int key="objectID">6</int>
 						<reference key="object" ref="774585933"/>
 						<array class="NSMutableArray" key="children">
-							<object class="IBNSLayoutConstraint" id="500349722">
-								<reference key="firstItem" ref="774585933"/>
-								<int key="firstAttribute">6</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="1016960852"/>
-								<int key="secondAttribute">6</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="774585933"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="1018268004">
-								<reference key="firstItem" ref="587036035"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="774585933"/>
-								<int key="secondAttribute">5</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="774585933"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="233853418">
-								<reference key="firstItem" ref="774585933"/>
-								<int key="firstAttribute">6</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="587036035"/>
-								<int key="secondAttribute">6</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="774585933"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="665033475">
-								<reference key="firstItem" ref="587036035"/>
-								<int key="firstAttribute">3</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="774585933"/>
-								<int key="secondAttribute">3</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">170</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="774585933"/>
-								<int key="scoringType">3</int>
-								<float key="scoringTypeFloat">9</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="559097115">
-								<reference key="firstItem" ref="261442737"/>
-								<int key="firstAttribute">5</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="774585933"/>
-								<int key="secondAttribute">5</int>
-								<float key="multiplier">1</float>
-								<object class="IBNSLayoutSymbolicConstant" key="constant">
-									<double key="value">20</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="774585933"/>
-								<int key="scoringType">8</int>
-								<float key="scoringTypeFloat">29</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="537729006">
-								<reference key="firstItem" ref="261442737"/>
-								<int key="firstAttribute">3</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="774585933"/>
-								<int key="secondAttribute">3</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">86</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="774585933"/>
-								<int key="scoringType">3</int>
-								<float key="scoringTypeFloat">9</float>
-								<int key="contentType">3</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="578115730">
-								<reference key="firstItem" ref="261442737"/>
-								<int key="firstAttribute">11</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="1016960852"/>
-								<int key="secondAttribute">11</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="774585933"/>
-								<int key="scoringType">6</int>
-								<float key="scoringTypeFloat">24</float>
-								<int key="contentType">2</int>
-							</object>
 							<reference ref="261442737"/>
 							<reference ref="1016960852"/>
 							<reference ref="587036035"/>
+							<reference ref="591450706"/>
+							<reference ref="1036339194"/>
 						</array>
 						<reference key="parent" ref="0"/>
 					</object>
@@ -343,66 +300,20 @@
 						<reference key="parent" ref="774585933"/>
 					</object>
 					<object class="IBObjectRecord">
-						<int key="objectID">17</int>
-						<reference key="object" ref="578115730"/>
-						<reference key="parent" ref="774585933"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">18</int>
-						<reference key="object" ref="537729006"/>
-						<reference key="parent" ref="774585933"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">19</int>
-						<reference key="object" ref="559097115"/>
-						<reference key="parent" ref="774585933"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">21</int>
-						<reference key="object" ref="500349722"/>
-						<reference key="parent" ref="774585933"/>
-					</object>
-					<object class="IBObjectRecord">
 						<int key="objectID">22</int>
 						<reference key="object" ref="587036035"/>
-						<array class="NSMutableArray" key="children">
-							<object class="IBNSLayoutConstraint" id="1010474338">
-								<reference key="firstItem" ref="587036035"/>
-								<int key="firstAttribute">8</int>
-								<int key="relation">0</int>
-								<nil key="secondItem"/>
-								<int key="secondAttribute">0</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">34</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="587036035"/>
-								<int key="scoringType">3</int>
-								<float key="scoringTypeFloat">9</float>
-								<int key="contentType">1</int>
-							</object>
-						</array>
+						<array class="NSMutableArray" key="children"/>
 						<reference key="parent" ref="774585933"/>
 					</object>
 					<object class="IBObjectRecord">
-						<int key="objectID">31</int>
-						<reference key="object" ref="1010474338"/>
-						<reference key="parent" ref="587036035"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">29</int>
-						<reference key="object" ref="1018268004"/>
+						<int key="objectID">38</int>
+						<reference key="object" ref="591450706"/>
+						<array class="NSMutableArray" key="children"/>
 						<reference key="parent" ref="774585933"/>
 					</object>
 					<object class="IBObjectRecord">
-						<int key="objectID">28</int>
-						<reference key="object" ref="233853418"/>
-						<reference key="parent" ref="774585933"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">23</int>
-						<reference key="object" ref="665033475"/>
+						<int key="objectID">50</int>
+						<reference key="object" ref="1036339194"/>
 						<reference key="parent" ref="774585933"/>
 					</object>
 				</array>
@@ -413,45 +324,183 @@
 				<string key="-2.CustomClassName">UIResponder</string>
 				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="13.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<boolean value="NO" key="13.IBViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
-				<string key="17.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="18.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="19.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="21.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="22.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<array key="22.IBViewMetadataConstraints">
-					<reference ref="1010474338"/>
-				</array>
-				<boolean value="NO" key="22.IBViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
-				<string key="23.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="28.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="29.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="31.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<array key="22.IBViewMetadataConstraints"/>
+				<string key="38.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<array key="38.IBViewMetadataConstraints"/>
+				<string key="50.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<reference key="50.IBViewMetadataConstraints" ref="0"/>
+				<reference key="6.IBNSViewMetadataGestureRecognizers" ref="0"/>
 				<string key="6.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<array key="6.IBViewMetadataConstraints">
-					<reference ref="578115730"/>
-					<reference ref="537729006"/>
-					<reference ref="559097115"/>
-					<reference ref="665033475"/>
-					<reference ref="233853418"/>
-					<reference ref="1018268004"/>
-					<reference ref="500349722"/>
-				</array>
+				<array key="6.IBViewMetadataConstraints"/>
 				<string key="8.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<boolean value="NO" key="8.IBViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
 			</dictionary>
 			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">37</int>
+			<int key="maxID">53</int>
 		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes"/>
+		<object class="IBClassDescriber" key="IBDocument.Classes">
+			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
+				<object class="IBPartialClassDescription">
+					<string key="className">ViewController</string>
+					<string key="superclassName">UIViewController</string>
+					<dictionary class="NSMutableDictionary" key="actions">
+						<string key="onSelectColor:">id</string>
+						<string key="onSelectDate:">id</string>
+						<string key="onSelectFloatRange:">id</string>
+						<string key="onSelectTimeRange:">id</string>
+					</dictionary>
+					<dictionary class="NSMutableDictionary" key="actionInfosByName">
+						<object class="IBActionInfo" key="onSelectColor:">
+							<string key="name">onSelectColor:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+						<object class="IBActionInfo" key="onSelectDate:">
+							<string key="name">onSelectDate:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+						<object class="IBActionInfo" key="onSelectFloatRange:">
+							<string key="name">onSelectFloatRange:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+						<object class="IBActionInfo" key="onSelectTimeRange:">
+							<string key="name">onSelectTimeRange:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</dictionary>
+					<object class="NSMutableDictionary" key="outlets">
+						<string key="NS.key.0">resultLabel</string>
+						<string key="NS.object.0">UILabel</string>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<string key="NS.key.0">resultLabel</string>
+						<object class="IBToOneOutletInfo" key="NS.object.0">
+							<string key="name">resultLabel</string>
+							<string key="candidateClassName">UILabel</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">../ModalPickerDemo/ViewController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">ViewController</string>
+					<dictionary class="NSMutableDictionary" key="actions">
+						<string key="onSelectColor:">id</string>
+						<string key="onSelectDate:">id</string>
+						<string key="onSelectFloatRange:">id</string>
+						<string key="onSelectTimeRange:">id</string>
+					</dictionary>
+					<dictionary class="NSMutableDictionary" key="actionInfosByName">
+						<object class="IBActionInfo" key="onSelectColor:">
+							<string key="name">onSelectColor:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+						<object class="IBActionInfo" key="onSelectDate:">
+							<string key="name">onSelectDate:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+						<object class="IBActionInfo" key="onSelectFloatRange:">
+							<string key="name">onSelectFloatRange:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+						<object class="IBActionInfo" key="onSelectTimeRange:">
+							<string key="name">onSelectTimeRange:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</dictionary>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">../ModalPickerDemo/ViewController.m</string>
+					</object>
+				</object>
+			</array>
+			<array class="NSMutableArray" key="referencedPartialClassDescriptionsV3.2+">
+				<object class="IBPartialClassDescription">
+					<string key="className">UIButton</string>
+					<string key="superclassName">UIControl</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIButton.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIControl</string>
+					<string key="superclassName">UIView</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIControl.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIGestureRecognizer</string>
+					<string key="superclassName">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIGestureRecognizer.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UILabel</string>
+					<string key="superclassName">UIView</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UILabel.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIResponder</string>
+					<string key="superclassName">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIResponder.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UISearchBar</string>
+					<string key="superclassName">UIView</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UISearchBar.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UISearchDisplayController</string>
+					<string key="superclassName">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UISearchDisplayController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIView</string>
+					<string key="superclassName">UIResponder</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIView.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">UIViewController</string>
+					<string key="superclassName">UIResponder</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIViewController.h</string>
+					</object>
+				</object>
+			</array>
+		</object>
 		<int key="IBDocument.localizationMode">0</int>
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
+		<bool key="IBDocument.previouslyAttemptedUpgradeToXcode5">NO</bool>
+		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.InterfaceBuilder3</string>
+			<integer value="4600" key="NS.object.0"/>
+		</object>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<bool key="IBDocument.UseAutolayout">YES</bool>
-		<string key="IBCocoaTouchPluginVersion">2083</string>
 	</data>
 </archive>


### PR DESCRIPTION
Includes float (CGFloat) and time (NSDate) range picker examples, including an update to the sample project to demonstrate usage.

BSModalFloatRangePickerView is useful for choosing currency or price ranges.
BSModalTimeRangePickerView is useful for choosing a time range.

Cheers!