### PR TITLE
Use correct picker view when selecting index.

### DIFF
--- a/BSModalPickerView/BSModalPickerBase.h
+++ b/BSModalPickerView/BSModalPickerBase.h
@@ -46,5 +46,7 @@ typedef void (^BSModalPickerViewCallback)(BOOL madeChoice);
 
 /* Override and return any additional buttons that you want on the toolbar.  By default, this is just a flexible space item. */
 - (NSArray *)additionalToolbarItems;
+
+@property (nonatomic) UIBarStyle toolbarStyle;
     
 @end

--- a/BSModalPickerView/BSModalPickerBase.m
+++ b/BSModalPickerView/BSModalPickerBase.m
@@ -19,11 +19,14 @@
 
 @implementation BSModalPickerBase
 
+@synthesize toolbarStyle;
+
 #pragma mark - Designated Initializer
 
 - (id)init {
     self = [super init];
     if (self) {
+        self.toolbarStyle = UIBarStyleBlackTranslucent;
         self.autoresizesSubviews = YES;
         self.presentBackdropView = YES;
         self.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
@@ -65,7 +68,7 @@
 - (UIToolbar *)toolbar {
     if (!_toolbar) {
         _toolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0, 0, self.bounds.size.width, BSMODALPICKER_TOOLBAR_HEIGHT)];
-        _toolbar.barStyle = UIBarStyleBlackTranslucent;
+        _toolbar.barStyle = toolbarStyle;
         UIBarButtonItem *cancelButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
                                                                                   target:self
                                                                                   action:@selector(onCancel:)];

--- a/BSModalPickerView/BSModalPickerView.m
+++ b/BSModalPickerView/BSModalPickerView.m
@@ -59,8 +59,8 @@
 - (void)setSelectedIndex:(NSUInteger)selectedIndex {
     if (_selectedIndex != selectedIndex) {
         _selectedIndex = selectedIndex;
-        if (self.picker) {
-            UIPickerView *pickerView = (UIPickerView *)self.picker;
+        if (_picker) {
+            UIPickerView *pickerView = (UIPickerView *)_picker;
             [pickerView selectRow:selectedIndex inComponent:0 animated:YES];
         }
     }

--- a/BSModalPickerView/BSModalPickerView.m
+++ b/BSModalPickerView/BSModalPickerView.m
@@ -59,6 +59,7 @@
 - (void)setSelectedIndex:(NSUInteger)selectedIndex {
     if (_selectedIndex != selectedIndex) {
         _selectedIndex = selectedIndex;
+        self.indexSelectedBeforeDismissal = selectedIndex;
         if (_picker) {
             UIPickerView *pickerView = (UIPickerView *)_picker;
             [pickerView selectRow:selectedIndex inComponent:0 animated:YES];


### PR DESCRIPTION
In BSModalPickerView, when selecting an index, fix the picker view that
is used from parent.
