### PR TITLE
Fix SelectedImage > 0 not displaying values

### DIFF
--- a/BSModalPickerView/BSModalPickerView.m
+++ b/BSModalPickerView/BSModalPickerView.m
@@ -59,7 +59,7 @@
 - (void)setSelectedIndex:(NSUInteger)selectedIndex {
     if (_selectedIndex != selectedIndex) {
         _selectedIndex = selectedIndex;
-        if (self.picker) {
+        if (_picker) {
             UIPickerView *pickerView = (UIPickerView *)self.picker;
             [pickerView selectRow:selectedIndex inComponent:0 animated:YES];
         }


### PR DESCRIPTION
Fix.

The BSModalPickerView did not show any values if the SelectedIndex is greater than 0.

Affects iOS9.

To reproduce on Demo project

Open Color Picker
Select Red Color
Done
Open Color Picker
